### PR TITLE
Feat sc-8790: Fetch Blockhashes From Blockchain API for BitcoinKit Mainnet

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["Hodler"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/moneyclip-io/BitcoinCore.Swift.git", branch: "feat/sc-8646-Use-Blockchain-API-for-Testnet-Sync"),
+        .package(url: "https://github.com/moneyclip-io/BitcoinCore.Swift.git", branch: "feat/8790-Fetch-Blockhashes-From-Blockchain-API-for-Mainnet"),
         .package(url: "https://github.com/horizontalsystems/HsCryptoKit.Swift.git", .upToNextMajor(from: "1.0.0")),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["Hodler"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/moneyclip-io/BitcoinCore.Swift.git", branch: "feat/8790-Fetch-Blockhashes-From-Blockchain-API-for-Mainnet"),
+        .package(url: "https://github.com/moneyclip-io/BitcoinCore.Swift.git", branch: "feat/sc-8790-Fetch-Blockhashes-From-Blockchain-API-for-Mainnet"),
         .package(url: "https://github.com/horizontalsystems/HsCryptoKit.Swift.git", .upToNextMajor(from: "1.0.0")),
     ],
     targets: [


### PR DESCRIPTION
# Shortcut
[8790](https://app.shortcut.com/moneyclipio/story/8790/bitcoinkit-ios-fetch-blockhashes-from-blockchain-api-for-bitcoinkit-mainnet)
# Description
- Point `BitcoinCore` dependency to a different branch.